### PR TITLE
sort 実装 

### DIFF
--- a/202504/sort/go/impl/sort_implementation.go
+++ b/202504/sort/go/impl/sort_implementation.go
@@ -1,41 +1,114 @@
 package impl
 
 import (
-	"reflect"
-	"sort"
+	"sync"
 )
 
-// SortImplementation はソートアルゴリズムの基本実装を提供する
-type SortImplementation struct{}
+// グローバル定数
+const (
+	INSERTION_SORT_THRESHOLD = 10
+	MAX_PARALLEL_DEPTH       = 4
+)
 
-// SortSliceOrdered は「比較演算子 < が使える型」だけを対象にソートする
-func (s *SortImplementation) Sort(data []interface{}) []interface{} {
-	// 元スライスをコピー
-	newArr := make([]interface{}, len(data))
-	copy(newArr, data)
-	el := newArr[0]
+// SortImplementation はジェネリックなソート実装を提供する
+type SortImplementation[T any] struct{}
 
-	if reflect.TypeOf(el) == reflect.TypeOf(0) {
-		// 数値型の場合
-		sort.Slice(newArr, func(i, j int) bool {
-			return newArr[i].(int) < newArr[j].(int)
-		})
-		return newArr
-	}
-	if reflect.TypeOf(el) == reflect.TypeOf("") {
-		// 文字列型の場合
-		sort.Slice(newArr, func(i, j int) bool {
-			return newArr[i].(string) < newArr[j].(string)
-		})
-		return newArr
-	}
-	if reflect.TypeOf(el) == reflect.TypeOf(0.0) {
-		// 浮動小数点型の場合
-		sort.Slice(newArr, func(i, j int) bool {
-			return newArr[i].(float64) < newArr[j].(float64)
-		})
-		return newArr
+func (s *SortImplementation[T]) Sort(array []T, less func(a, b T) bool) []T {
+	arrCopy := make([]T, len(array))
+	copy(arrCopy, array)
+
+	ParallelQuickSort(arrCopy, less)
+	return arrCopy
+}
+
+// ParallelQuickSort メソッドで並列クイックソートを使用
+func ParallelQuickSort[T any](arr []T, less func(a, b T) bool) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go parallelQuickSort(arr, 0, len(arr)-1, less, 0, &wg)
+	wg.Wait()
+}
+
+// クイックソート（並列版）
+func parallelQuickSort[T any](arr []T, low, high int, less func(a, b T) bool, depth int, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if high-low+1 <= INSERTION_SORT_THRESHOLD {
+		insertionSort(arr, low, high, less)
+		return
 	}
 
-	return newArr
+	p := partition(arr, low, high, less)
+
+	if depth < MAX_PARALLEL_DEPTH {
+		wg.Add(2)
+		go parallelQuickSort(arr, low, p-1, less, depth+1, wg)
+		go parallelQuickSort(arr, p+1, high, less, depth+1, wg)
+	} else {
+		quickSort(arr, low, p-1, less)
+		quickSort(arr, p+1, high, less)
+	}
+}
+
+// 通常クイックソート（再帰で使う）
+func quickSort[T any](arr []T, low, high int, less func(a, b T) bool) {
+	for low < high {
+		if high-low+1 <= INSERTION_SORT_THRESHOLD {
+			insertionSort(arr, low, high, less)
+			break
+		}
+		p := partition(arr, low, high, less)
+		if p-low < high-p {
+			quickSort(arr, low, p-1, less)
+			low = p + 1
+		} else {
+			quickSort(arr, p+1, high, less)
+			high = p - 1
+		}
+	}
+}
+
+// 挿入ソート
+func insertionSort[T any](arr []T, low, high int, less func(a, b T) bool) {
+	for i := low + 1; i <= high; i++ {
+		key := arr[i]
+		j := i - 1
+		for j >= low && less(key, arr[j]) {
+			arr[j+1] = arr[j]
+			j--
+		}
+		arr[j+1] = key
+	}
+}
+
+// 三点中央値パーティション
+func partition[T any](arr []T, low, high int, less func(a, b T) bool) int {
+	mid := (low + high) / 2
+
+	if less(arr[mid], arr[low]) {
+		arr[low], arr[mid] = arr[mid], arr[low]
+	}
+	if less(arr[high], arr[low]) {
+		arr[low], arr[high] = arr[high], arr[low]
+	}
+	if less(arr[high], arr[mid]) {
+		arr[mid], arr[high] = arr[high], arr[mid]
+	}
+
+	arr[mid], arr[high-1] = arr[high-1], arr[mid]
+	pivot := arr[high-1]
+
+	i, j := low, high-1
+	for {
+		for i++; less(arr[i], pivot); i++ {
+		}
+		for j--; less(pivot, arr[j]); j-- {
+		}
+		if i >= j {
+			break
+		}
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+	arr[i], arr[high-1] = arr[high-1], arr[i]
+	return i
 }

--- a/202504/sort/go/impl/sort_performance_measurement.go
+++ b/202504/sort/go/impl/sort_performance_measurement.go
@@ -10,7 +10,7 @@ import (
 )
 
 // loadSortTestData は入力ファイルと期待値ファイルを読み込む
-func loadSortTestData(fileDir string) ([]interface{}, []interface{}, error) {
+func loadSortTestData(fileDir string, dataType string) ([]interface{}, []interface{}, error) {
 	// 入力データの読み込み
 	inputData, err := ioutil.ReadFile(strings.Join([]string{fileDir, "input.txt"}, "/"))
 	if err != nil {
@@ -22,12 +22,17 @@ func loadSortTestData(fileDir string) ([]interface{}, []interface{}, error) {
 	inputStr := strings.TrimSpace(string(inputData))
 	inputStr = strings.Trim(inputStr, "[]")
 	if inputStr != "" {
-		for _, numStr := range strings.Split(inputStr, ",") {
-			num, err := strconv.Atoi(strings.TrimSpace(numStr))
-			if err != nil {
-				return nil, nil, fmt.Errorf("数値のパースに失敗しました: %v", err)
+		for _, dataStr := range strings.Split(inputStr, ",") {
+			dataStr = strings.TrimSpace(dataStr)
+			if dataType == "int" {
+				num, err := strconv.Atoi(dataStr)
+				if err != nil {
+					return nil, nil, fmt.Errorf("数値のパースに失敗しました: %v", err)
+				}
+				array = append(array, num)
+			} else if dataType == "string" {
+				array = append(array, dataStr)
 			}
-			array = append(array, num)
 		}
 	}
 
@@ -42,12 +47,17 @@ func loadSortTestData(fileDir string) ([]interface{}, []interface{}, error) {
 	expectedStr := strings.TrimSpace(string(expectedData))
 	expectedStr = strings.Trim(expectedStr, "[]")
 	if expectedStr != "" {
-		for _, numStr := range strings.Split(expectedStr, ",") {
-			num, err := strconv.Atoi(strings.TrimSpace(numStr))
-			if err != nil {
-				return array, nil, fmt.Errorf("期待値のパースに失敗しました: %v", err)
+		for _, dataStr := range strings.Split(expectedStr, ",") {
+			dataStr = strings.TrimSpace(dataStr)
+			if dataType == "int" {
+				num, err := strconv.Atoi(dataStr)
+				if err != nil {
+					return array, nil, fmt.Errorf("期待値のパースに失敗しました: %v", err)
+				}
+				expectedOutput = append(expectedOutput, num)
+			} else if dataType == "string" {
+				expectedOutput = append(expectedOutput, dataStr)
 			}
-			expectedOutput = append(expectedOutput, num)
 		}
 	}
 
@@ -55,15 +65,15 @@ func loadSortTestData(fileDir string) ([]interface{}, []interface{}, error) {
 }
 
 // MeasureSortPerformance はSortの性能と正当性を計測する
-func MeasureSortPerformance(fileDir string, iterations int) map[string]interface{} {
+func MeasureSortPerformance(fileDir string, iterations int, dataType string) map[string]interface{} {
 	var err error
-	array, expectedOutput, err := loadSortTestData(fileDir)
+	array, expectedOutput, err := loadSortTestData(fileDir, dataType)
 	if err != nil {
 		fmt.Println(err)
 		return nil
 	}
 
-	sorter := &SortImplementation{}
+	sorter := &SortImplementation[interface{}]{}
 
 	fmt.Printf("Sort実装のパフォーマンス計測と正当性検証:\n")
 	fmt.Printf("配列サイズ: %d\n", len(array))
@@ -78,18 +88,28 @@ func MeasureSortPerformance(fileDir string, iterations int) map[string]interface
 			arrayCopy := make([]interface{}, len(array))
 			copy(arrayCopy, array)
 
-			sorted = sorter.Sort(arrayCopy)
+			sorted = sorter.Sort(arrayCopy, func(a, b interface{}) bool {
+				// less 関数でタイプに応じて比較
+				switch v := a.(type) {
+				case int:
+					return v < b.(int)
+				case string:
+					return v < b.(string)
+				default:
+					return false
+				}
+			})
 			if iterations == 1 {
 				// ソート前とソート後の最初の5要素を表示
 				fmt.Printf("ソート前の先頭5要素: ")
 				for j := 0; j < 5 && j < len(array); j++ {
-					fmt.Printf("%d ", array[j])
+					fmt.Printf("%v ", array[j])
 				}
 				fmt.Println()
 
 				fmt.Printf("ソート後の先頭5要素: ")
 				for j := 0; j < 5 && j < len(sorted); j++ {
-					fmt.Printf("%d ", sorted[j])
+					fmt.Printf("%v ", sorted[j])
 				}
 				fmt.Println()
 			}

--- a/202504/sort/go/main.go
+++ b/202504/sort/go/main.go
@@ -3,8 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-
-	impl "study-session/sort/go/impl"
+	"study-session/sort/go/impl"
 )
 
 // ===============================================
@@ -12,32 +11,40 @@ import (
 // ===============================================
 
 func main() {
+	// プログラム開始時に表示するメッセージ
 	fmt.Println("==============================")
 	fmt.Println("Sort性能計測と正当性検証")
 	fmt.Println("==============================")
 
-	// Sort計測と検証
+	// ソートの計測と検証を開始
 	fmt.Println("Sort実装のテスト")
-	fileDir := os.Args[1]
-	sortResults := impl.MeasureSortPerformance(fileDir, 1)
+	fileDir := os.Args[1]                                            // コマンドライン引数からファイルディレクトリを取得
+	sortResults := impl.MeasureSortPerformance(fileDir, 1, "string") // ソートのパフォーマンスを計測
 
-	// 検証結果の要約
+	// 検証結果の要約を表示
 	fmt.Println("\n==============================")
 	fmt.Println("テスト結果サマリー")
 	fmt.Println("==============================")
 
+	// ソート結果の検証
 	sortValid := false
 	if sortResults != nil {
-		sortValid, _ = sortResults["valid"].(bool)
+		// "valid"キーの値がbool型か確認し、bool型の場合に変換
+		if valid, ok := sortResults["valid"].(bool); ok {
+			sortValid = valid // bool型に変換できた場合、変数に結果を格納
+		}
 	}
 
+	// 結果を表示
 	fmt.Printf("Sort: %s\n", boolToCheckmark(sortValid))
 }
 
 // boolToCheckmark はブール値をチェックマーク文字列に変換
 func boolToCheckmark(b bool) string {
 	if b {
+		// 成功の場合は「成功 ✓」を返す
 		return "成功 ✓"
 	}
+	// 失敗の場合は「失敗 ✗」を返す
 	return "失敗 ✗"
 }


### PR DESCRIPTION
## 変更内容

- `SortImplementation` をジェネリクス対応にし、任意の型に対応できるように変更
- 並列クイックソート（Parallel QuickSort）の導入で高速化を実現
- `loadSortTestData` 関数を修正し、`dataType`（int/string）を指定可能に変更
- `MeasureSortPerformance` に `dataType` 引数を追加し、柔軟な型対応を可能に
- `main.go` もそれに合わせて `MeasureSortPerformance` 呼び出しを更新

## テスト方法

1. `input.txt` および `expected.txt` を int/string 型に合わせて作成
2. 以下のコマンドを実行：
   ```bash
   go run main.go "./sort/test_cases/ テストケース名"
3. 次の点を確認：
- 「成功 ✓」が表示されるか
- ソート前後のデータの先頭5件が表示されるか
- エラーが出ないか

## 動作確認済みケース

- 数値（`int`）ソート  
- 文字列（`string`）ソート

##  その他

- 並列処理は深さ制限を設けて制御（`MAX_PARALLEL_DEPTH = 4`）  
- 小さい配列は挿入ソートで対応（`INSERTION_SORT_THRESHOLD = 10`）  
